### PR TITLE
v0.7.0 -- SDK table bump + Article 4a docs (CI dry-run)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -27,10 +27,101 @@ cloakllm verify ./cloakllm_audit/ --format compliance_report
 Returns a structured report with `verdict: "COMPLIANT"` or `"NON_COMPLIANT"` plus a list of detected anomalies.
 
 ### Article 4a — Data Processing for Bias Detection
-**Status:** Partial (full implementation in v0.7.0)
-**How (today):** CloakLLM's deterministic tokenization qualifies as pseudonymisation under GDPR Recital 26 and Article 4(5), which is the baseline requirement of Article 4a. Tokens such as `[PERSON_0]`, `[PHONE_3]`, `[EMAIL_2]` cannot be re-attributed to an individual without the in-memory token map (which is never persisted).
+**Status:** Satisfied (v0.7.0+)
 
-**Coming in v0.7.0:** A dedicated `BiasDetectionSession` API enabling pseudonymised processing of GDPR Article 9 special-category data (health, ethnic origin, religious beliefs, political opinion, biometric identifiers, sexual orientation) for the explicit purpose of bias auditing in high-risk AI systems.
+Article 4a (added to the EU AI Act by the May 7 2026 Digital Omnibus) permits the processing of GDPR Article 9 special-category data — race, ethnic origin, religion, political opinion, health, biometric data, sexual orientation, trade union membership, genetic data — strictly for the purpose of bias detection and correction in AI systems, subject to six safeguards.
+
+**How:** the `BiasDetectionSession` API (Python: `cloakllm.BiasDetectionSession`, JS: `BiasDetectionSession.run({...}, fn)`) wraps an Article 4a workflow over an existing Shield. Article 4a builds on Article 12 — the underlying Shield must be in `compliance_mode="eu_ai_act_article12"`; the session refuses to start otherwise. Bias-detection events get `EU_AI_Act_Art_4a` appended to `article_ref` while keeping `EU_AI_Act_Art_12` so the same audit chain satisfies both articles.
+
+#### Safeguard mapping
+
+| Article 4a safeguard | CloakLLM implementation |
+|---|---|
+| 1. No less-intrusive alternative exists | `necessity_justification` constructor field (≤ 2000 chars), persisted to the audit chain. The operator records contemporaneously why synthetic / anonymised data is insufficient. |
+| 2. Pseudonymisation | `session.pseudonymise(text, force_categories=[...])` substitutes caller-declared spans with deterministic `[RACE_0]` / `[RELIGION_1]` / etc. tokens. No regex auto-detection — declarative spans only. |
+| 3. State-of-the-art security | Session-local in-memory `TokenMap`; never persisted; HMAC-SHA256 entity hashes (existing v0.2.1 infrastructure) available when `entity_hashing` is enabled. Audit chain uses SHA-256 hash linkage + optional Ed25519 attestation. |
+| 4. Technical limitations on re-use | `categories_allowed` whitelist enforced at construction time. Any `pseudonymise` call requesting a category outside the set raises `BiasDetectionScopeError` and writes nothing to the audit chain or token map. |
+| 5. Deletion after bias correction | `max_lifetime_seconds` is required (no default) with a hard 7-day ceiling. On `__exit__` (Python) / `.end()` (both SDKs) / lifetime expiry, the session token map is wiped: dict values overwritten with empty strings, `forward` / `reverse` / `_counters` / `detections` cleared, the `TokenMap` reference dropped. `wipe_confirmed: true` is recorded in the `bias_session_end` audit entry. |
+| 6. Recorded justification | Every operation flows into the existing Article 12 hash-chained audit log as a new event type — `bias_session_start`, `bias_pseudonymise`, `bias_finding`, `bias_session_end`. The `bias_context` field on each entry carries the session lifecycle metadata (purpose, justification, categories, lifetime, finding summary, wipe confirmation, exit reason). |
+
+#### Audit-trail shape
+
+| `event_type` | When | Distinct fields recorded (in `bias_context`) |
+|---|---|---|
+| `bias_session_start` | `__enter__` / `.start()` | `session_id`, `purpose`, `necessity_justification`, `categories_allowed`, `max_lifetime_seconds` |
+| `bias_pseudonymise` | each `.pseudonymise()` call | `session_id`, `entity_count`, `categories_used` |
+| `bias_finding` | each `.record_finding()` call | `session_id`, `finding_summary` (≤ 500 chars), `bias_metrics` (B3-validated dict) |
+| `bias_session_end` | `__exit__` / `.end()` / lifetime expiry | `session_id`, `exit_reason` (`clean` / `error` / `timeout` / `evicted`), `wipe_confirmed`, `entries_processed`, `duration_seconds` |
+
+All four entries pass the always-on B3 schema validator (no source PII anywhere — `bias_context` is a strict per-key allow-list with per-key length caps; `necessity_justification` gets a wider 2000-char cap than the regular `metadata` field but the same PII-forbidden-key list applies).
+
+#### Example (Python)
+
+```python
+from cloakllm import Shield, ShieldConfig, BiasDetectionSession
+
+shield = Shield(ShieldConfig(compliance_mode="eu_ai_act_article12"))
+
+with BiasDetectionSession(
+    shield=shield,
+    purpose="Pre-deployment fairness audit of credit-scoring model v3.2",
+    necessity_justification=(
+        "Synthetic data evaluated and rejected — does not preserve covariance "
+        "between protected characteristics and credit history. See internal "
+        "report XYZ-2026-04."
+    ),
+    categories_allowed={"RACE", "ETHNICITY", "RELIGION"},
+    max_lifetime_seconds=86400,  # 24 hours
+) as session:
+    for record in dataset:
+        pseudonymised, _ = session.pseudonymise(
+            record["text"],
+            force_categories=record["spans"],  # [(start, end, category), ...]
+        )
+        # run bias-detection over `pseudonymised` ...
+    session.record_finding(
+        finding_summary="No significant disparate impact detected.",
+        bias_metrics={"demographic_parity_diff": 0.012, "sample_size": 5000},
+    )
+# On exit: token map wiped, bias_session_end logged with wipe_confirmed=true.
+```
+
+#### Example (JavaScript)
+
+```js
+const { Shield, ShieldConfig, BiasDetectionSession } = require('cloakllm');
+
+const shield = new Shield(new ShieldConfig({
+  complianceMode: 'eu_ai_act_article12',
+}));
+
+await BiasDetectionSession.run({
+  shield,
+  purpose: 'Pre-deployment fairness audit of credit-scoring model v3.2',
+  necessityJustification: 'Synthetic data evaluated and rejected. See report XYZ-2026-04.',
+  categoriesAllowed: ['RACE', 'ETHNICITY', 'RELIGION'],
+  maxLifetimeSeconds: 86400,
+}, (session) => {
+  for (const record of dataset) {
+    const [pseudonymised, _] = session.pseudonymise(record.text, {
+      forceCategories: record.spans,
+    });
+    // ...
+  }
+  session.recordFinding({
+    findingSummary: 'No significant disparate impact detected.',
+    biasMetrics: { demographic_parity_diff: 0.012, sample_size: 5000 },
+  });
+});
+```
+
+#### Interaction with Article 10(5)
+
+Article 4a is broader than the predecessor Article 10(5) (which applied only to HRAIS providers). Article 4a covers **both providers and deployers of any AI system** engaged in bias detection. CloakLLM's `BiasDetectionSession` does not distinguish — the same workflow satisfies either article when the safeguard mapping above is followed.
+
+#### Post-deletion forensics — by design
+
+After `bias_session_end` the in-memory token map is wiped. The audit chain retains entry counts, categories, timing, and finding summaries but **cannot be used to reconstruct source values from tokens**. This is the Article 4a safeguard #5 guarantee, not a forensics gap — auditors verify *what happened* (sessions opened, justifications recorded, categories within scope, deletion confirmed) without the ability to re-identify the data subjects.
 
 ---
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -39,6 +39,7 @@ PII protection middleware for LLMs — detect, tokenize, and audit before prompt
 - [Token Specification](#token-specification)
 - [Pluggable Detection Backends](#pluggable-detection-backends)
 - [Article 12 Compliance Mode](#article-12-compliance-mode)
+- [Article 4a Bias Detection Workflow](#article-4a-bias-detection-workflow-v070) **(v0.7.0)**
 - [Enterprise Key Management](#enterprise-key-management)
 - [Disabling / Re-enabling](#disabling--re-enabling)
 
@@ -1838,6 +1839,120 @@ Emits the report as JSON to stdout. Exit code `0` for COMPLIANT, `1` for NON_COM
 ### The PII guard
 
 In compliance mode, every audit entry passes through `_assert_no_pii_in_entry` before being hashed. If any field of `entity_details` contains forbidden keys (`original_value`, `original_text`, `raw_text`, `plain_text`, `value`), the write is rejected with a `RuntimeError`. This is the structural enforcement of CloakLLM's core invariant: **audit logs contain zero original PII.**
+
+---
+
+## Article 4a Bias Detection Workflow (v0.7.0+)
+
+The EU AI Act's new **Article 4a** (added by the May 7 2026 Digital Omnibus) permits processing GDPR Article 9 special-category data — race, ethnic origin, religion, political opinion, health, biometric data, sexual orientation, trade union membership, genetic data — strictly for **bias detection and correction in AI systems**, subject to six safeguards.
+
+CloakLLM's `BiasDetectionSession` operationalises all six. The session is a **sibling class** over a `Shield` (composition, not inheritance) and requires the underlying Shield to be in `compliance_mode="eu_ai_act_article12"` — Article 4a builds on Article 12.
+
+### Eight new special-category tokens
+
+`SPECIAL_CATEGORY_CATEGORIES` (added v0.7.0): `RACE`, `ETHNICITY`, `RELIGION`, `POLITICAL_OPINION`, `HEALTH_BIOMETRIC`, `SEXUAL_ORIENTATION`, `TRADE_UNION`, `GENETIC`. These are **deliberately not auto-detected by regex** — the patterns have unacceptably high false-positive rates and the categories are context-dependent. Spans are introduced either by caller-declared `force_categories` in `pseudonymise()` or by opt-in LLM detection.
+
+### Python
+
+```python
+from cloakllm import Shield, ShieldConfig, BiasDetectionSession
+
+shield = Shield(ShieldConfig(compliance_mode="eu_ai_act_article12"))
+
+with BiasDetectionSession(
+    shield=shield,
+    purpose="Pre-deployment fairness audit of credit-scoring model v3.2",
+    necessity_justification=(
+        "Synthetic data evaluated and rejected — does not preserve "
+        "covariance between protected characteristics and credit history. "
+        "See internal report XYZ-2026-04."
+    ),
+    categories_allowed={"RACE", "ETHNICITY", "RELIGION"},
+    max_lifetime_seconds=86400,  # 24 hours (required; max 7 days)
+) as session:
+    for record in protected_dataset:
+        pseudonymised, counts = session.pseudonymise(
+            record["text"],
+            force_categories=[(s, e, cat) for s, e, cat in record["spans"]],
+        )
+        # ... run bias-detection over `pseudonymised` ...
+    session.record_finding(
+        finding_summary="No significant disparate impact detected.",
+        bias_metrics={"demographic_parity_diff": 0.012, "sample_size": 5000},
+    )
+# On exit: session token map wiped (best-effort secure overwrite + reference
+# drop), bias_session_end entry logged with wipe_confirmed=True.
+```
+
+### JavaScript
+
+```javascript
+const { Shield, ShieldConfig, BiasDetectionSession } = require('cloakllm');
+
+const shield = new Shield(new ShieldConfig({
+  complianceMode: 'eu_ai_act_article12',
+}));
+
+await BiasDetectionSession.run({
+  shield,
+  purpose: 'Pre-deployment fairness audit of credit-scoring model v3.2',
+  necessityJustification: 'Synthetic data evaluated and rejected. See report XYZ-2026-04.',
+  categoriesAllowed: ['RACE', 'ETHNICITY', 'RELIGION'],
+  maxLifetimeSeconds: 86400,
+}, (session) => {
+  for (const record of protectedDataset) {
+    const [pseudonymised, counts] = session.pseudonymise(record.text, {
+      forceCategories: record.spans, // [[start, end, category], ...]
+    });
+    // ...
+  }
+  session.recordFinding({
+    findingSummary: 'No significant disparate impact detected.',
+    biasMetrics: { demographic_parity_diff: 0.012, sample_size: 5000 },
+  });
+});
+```
+
+### Required fields
+
+| Field | Required | Purpose |
+|---|---|---|
+| `purpose` | yes | Free-text purpose (≤ 500 chars). Logged to the audit chain. Must not contain PII (the MCP layer additionally applies a PII-pattern scan before reaching the session). |
+| `necessity_justification` | yes | ≤ 2000 chars. Article 4a safeguard #1 — recorded reason why synthetic / anonymised data is insufficient. |
+| `categories_allowed` | yes | Non-empty subset of `SPECIAL_CATEGORY_CATEGORIES`. Out-of-scope categories at pseudonymise time raise `BiasDetectionScopeError`. |
+| `max_lifetime_seconds` | yes | 1 .. 604800 (7 days). No default — Article 4a safeguard #5 forces the operator to think about deletion timing. |
+
+### Errors
+
+| Exception | When |
+|---|---|
+| `BiasDetectionError` | Base class for all four. Inherits from `RuntimeError`. |
+| `BiasDetectionScopeError` | `pseudonymise()` called with a category not in `categories_allowed`. State unchanged: no token map mutation, no audit entry. |
+| `BiasDetectionTimeoutError` | Operation attempted after `max_lifetime_seconds` elapsed. The session is force-ended and wiped BEFORE the error is raised. |
+| `BiasDetectionStateError` | Operation on a session that is closed, or before `__enter__` / `.start()`. |
+
+### Audit-chain shape
+
+Each operation produces one entry, all part of the existing Article 12 hash chain:
+
+| event_type | bias_context fields |
+|---|---|
+| `bias_session_start` | session_id, purpose, necessity_justification, categories_allowed, max_lifetime_seconds |
+| `bias_pseudonymise` | session_id, entity_count, categories_used |
+| `bias_finding` | session_id, finding_summary (≤ 500 chars), bias_metrics (numeric dict, B3-validated) |
+| `bias_session_end` | session_id, exit_reason (clean/error/timeout/evicted), wipe_confirmed, entries_processed, duration_seconds |
+
+When the Shield is in `compliance_mode="eu_ai_act_article12"`, bias events get `EU_AI_Act_Art_4a` appended to `article_ref` — same chain satisfies both articles. All four entries pass the always-on B3 schema validator (no source PII anywhere).
+
+### Post-deletion forensics — by design
+
+After `bias_session_end` the in-memory token map is wiped. The audit chain retains entry counts, categories, timing, and finding summaries but **cannot be used to reconstruct source values from tokens**. This is the Article 4a safeguard #5 guarantee, not a forensics gap.
+
+### MCP
+
+Three new MCP tools (cloakllm-mcp 0.7.0+): `bias_detection_session_start`, `bias_pseudonymise`, `bias_detection_session_end`. The MCP layer adds a PII-pattern scan on `purpose` / `necessity_justification` / `finding_summary` before they reach the session, so PII-containing values are rejected with `{"error": "..."}` rather than reaching the audit chain.
+
+See [COMPLIANCE.md § Article 4a](COMPLIANCE.md) for the full safeguard mapping table.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Open-source PII protection middleware for LLMs. Detect sensitive data, replace i
 
 | SDK | Version | Install | Docs |
 |-----|---------|---------|------|
-| [CloakLLM-PY](https://github.com/cloakllm/CloakLLM-PY) | 0.6.5 | `pip install cloakllm` | [Python README](https://github.com/cloakllm/CloakLLM-PY#readme) |
-| [CloakLLM-JS](https://github.com/cloakllm/CloakLLM-JS) | 0.6.5 | `npm install cloakllm` | [JS/TS README](https://github.com/cloakllm/CloakLLM-JS#readme) |
-| [CloakLLM-MCP](https://github.com/cloakllm/cloakllm-mcp) | 0.6.5 | `python -m mcp run server.py` | [MCP README](https://github.com/cloakllm/cloakllm-mcp#readme) |
+| [CloakLLM-PY](https://github.com/cloakllm/CloakLLM-PY) | 0.7.0 | `pip install cloakllm` | [Python README](https://github.com/cloakllm/CloakLLM-PY#readme) |
+| [CloakLLM-JS](https://github.com/cloakllm/CloakLLM-JS) | 0.7.0 | `npm install cloakllm` | [JS/TS README](https://github.com/cloakllm/CloakLLM-JS#readme) |
+| [CloakLLM-MCP](https://github.com/cloakllm/cloakllm-mcp) | 0.7.0 | `python -m mcp run server.py` | [MCP README](https://github.com/cloakllm/cloakllm-mcp#readme) |
 
 ## What it does
 
@@ -49,6 +49,7 @@ Open-source PII protection middleware for LLMs. Detect sensitive data, replace i
 - **Normalized Token Standard** — formal spec ([TOKEN_SPEC.md](TOKEN_SPEC.md)) with validation utilities (`validateToken`, `parseToken`), canonical regex, and built-in category registry
 - **Pluggable Detection Backends** — `DetectorBackend` base class for custom detection pipelines; swap or extend the default regex→NER→LLM pipeline with your own backends
 - **Article 12 Compliance Mode** — formal EU AI Act compliance profile (`compliance_mode="eu_ai_act_article12"`) adds tamper-detectable compliance fields to every audit entry, plus `compliance_summary()` and structured `verify_audit(output_format="compliance_report")` for auditors. See [COMPLIANCE.md](COMPLIANCE.md).
+- **Article 4a Bias Detection Workflow** *(v0.7.0+)* — `BiasDetectionSession` context-managed API for processing GDPR Article 9 special-category PII (race, ethnicity, religion, political opinion, health/biometric, sexual orientation, trade union, genetic) strictly for AI bias detection and correction. Enforces all six Article 4a safeguards: recorded justification, pseudonymisation, in-memory-only token map, `categories_allowed` scope cap, hard-bounded `max_lifetime_seconds` with auto-wipe on exit, and full audit-chain recording. Builds on Article 12. See [COMPLIANCE.md § Article 4a](COMPLIANCE.md).
 - **Enterprise Key Management** *(experimental — disabled in v0.6.1)* — KMS/HSM provider scaffolding (AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault) is in place but currently raises `NotImplementedError`. Use `LocalKeyProvider` until v0.7.0.
 - **Security Hardened** — Ollama SSRF prevention, thread-safe operations, ReDoS protection, CLI PII redaction by default
 - **Detection Benchmark** — 108-sample labeled PII corpus with recall/precision/F1 harness, CI-enforced thresholds
@@ -106,11 +107,11 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-This exposes seven tools to Claude: **sanitize**, **sanitize_batch**, **desanitize**, **desanitize_batch**, **analyze**, **analyze_batch**, and **analyze_context_risk** (added v0.5.0).
+This exposes ten tools to Claude: **sanitize**, **sanitize_batch**, **desanitize**, **desanitize_batch**, **analyze**, **analyze_batch**, **analyze_context_risk** (added v0.5.0), and **bias_detection_session_start** / **bias_pseudonymise** / **bias_detection_session_end** (added v0.7.0 for the EU AI Act Article 4a workflow).
 
 ## Roadmap
 
-Upcoming: Article 4a bias-detection workflow for special-category PII (v0.7), structured compliance reporting API (v0.8), full EU AI Act suite (v1.0).
+Shipped in v0.7.0: Article 4a bias-detection workflow for special-category PII (`BiasDetectionSession`). Upcoming: KMS provider rebuild — AWS / GCP / Azure / Vault, one per v0.7.x point release — and the structured compliance reporting API (`generate_compliance_report()`) in v0.8.0. Full EU AI Act suite (sandbox-ready config, partner integrations, SME tier) in v1.0.
 
 ## License
 


### PR DESCRIPTION
Pre-release docs preview. Docs-only, no code changes.

## Summary
- README.md: SDK table -> 0.7.0; Article 4a feature line; MCP 7 -> 10 tools; roadmap update
- COMPLIANCE.md: Article 4a section rewritten from 'partial' -> 'satisfied' with full 6-safeguard mapping table, audit-trail shape, Py + JS code samples, Art 10(5) interaction note
- GUIDE.md: new 'Article 4a Bias Detection Workflow' section with full Py + JS walkthroughs, required fields, exception reference, audit-chain event shape

No tests in this repo; CI may show no checks or just markdown-lint.