### PR TITLE
docs: v0.8.0 -- SDK table + MCP tool count + roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Open-source PII protection middleware for LLMs. Detect sensitive data, replace i
 
 | SDK | Version | Install | Docs |
 |-----|---------|---------|------|
-| [CloakLLM-PY](https://github.com/cloakllm/CloakLLM-PY) | 0.7.1 | `pip install cloakllm` | [Python README](https://github.com/cloakllm/CloakLLM-PY#readme) |
-| [CloakLLM-JS](https://github.com/cloakllm/CloakLLM-JS) | 0.7.1 | `npm install cloakllm` | [JS/TS README](https://github.com/cloakllm/CloakLLM-JS#readme) |
-| [CloakLLM-MCP](https://github.com/cloakllm/cloakllm-mcp) | 0.7.1 | `python -m mcp run server.py` | [MCP README](https://github.com/cloakllm/cloakllm-mcp#readme) |
+| [CloakLLM-PY](https://github.com/cloakllm/CloakLLM-PY) | 0.8.0 | `pip install cloakllm` | [Python README](https://github.com/cloakllm/CloakLLM-PY#readme) |
+| [CloakLLM-JS](https://github.com/cloakllm/CloakLLM-JS) | 0.8.0 | `npm install cloakllm` | [JS/TS README](https://github.com/cloakllm/CloakLLM-JS#readme) |
+| [CloakLLM-MCP](https://github.com/cloakllm/cloakllm-mcp) | 0.8.0 | `python -m mcp run server.py` | [MCP README](https://github.com/cloakllm/cloakllm-mcp#readme) |
 
 ## What it does
 
@@ -107,11 +107,11 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-This exposes ten tools to Claude: **sanitize**, **sanitize_batch**, **desanitize**, **desanitize_batch**, **analyze**, **analyze_batch**, **analyze_context_risk** (added v0.5.0), and **bias_detection_session_start** / **bias_pseudonymise** / **bias_detection_session_end** (added v0.7.0 for the EU AI Act Article 4a workflow).
+This exposes **eleven tools** to Claude: **sanitize**, **sanitize_batch**, **desanitize**, **desanitize_batch**, **analyze**, **analyze_batch**, **analyze_context_risk** (added v0.5.0), **bias_detection_session_start** / **bias_pseudonymise** / **bias_detection_session_end** (added v0.7.0 for the EU AI Act Article 4a workflow), and **generate_compliance_report** (added v0.8.0 -- end-to-end EU AI Act compliance reports in JSON / Markdown).
 
 ## Roadmap
 
-Shipped in v0.7.0: Article 4a bias-detection workflow for special-category PII (`BiasDetectionSession`). Upcoming: KMS provider rebuild — AWS / GCP / Azure / Vault, one per v0.7.x point release — and the structured compliance reporting API (`generate_compliance_report()`) in v0.8.0. Full EU AI Act suite (sandbox-ready config, partner integrations, SME tier) in v1.0.
+Shipped in v0.8.0: end-to-end **compliance reporting API** (`Shield.generate_compliance_report()` Py + `shield.generateComplianceReport()` JS + new `generate_compliance_report` MCP tool + `cloakllm compliance-report` CLI). Pairs with v0.6.0 Article 12 Compliance Mode and v0.7.0 Article 4a bias-detection to produce one regulator-ready audit report per inference period (JSON / Markdown / PDF). Upcoming: v0.8.1 externally-verifiable KeyManifest (auditor verifies signatures without trusting CloakLLM) and KMS provider rebuild -- AWS / GCP / Azure / Vault. Full EU AI Act suite (sandbox-ready config, partner integrations, SME tier) in v1.0.
 
 ## License
 


### PR DESCRIPTION
## Summary

- SDK table version bumped 0.7.1 -> 0.8.0 across all 3 packages
- MCP tool count: **ten -> eleven** (new \`generate_compliance_report\` tool)
- Roadmap reflects shipped v0.8.0 compliance reporting headline; flags v0.8.1 KeyManifest as next.

## Test plan

- [x] Visual diff
- [ ] Merges after cloakllm-py / cloakllm-js / cloakllm-mcp v0.8.0 PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)